### PR TITLE
fix: lower python 3.14 scikit-learn floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ml4t-engineer are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b6] - 2026-05-05
+
+### Fixed
+- Lowered the Python 3.14 `scikit-learn` floor from `>=1.8.0` to `>=1.7.2`,
+  which already publishes `cp314` wheels and avoids unnecessary dependency
+  conflicts downstream
+
 ## [0.1.0b5] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "scipy>=1.10.0; python_version < '3.14'",
     "scipy>=1.17.0; python_version >= '3.14'",
     "scikit-learn>=1.3.0; python_version < '3.14'",
-    "scikit-learn>=1.8.0; python_version >= '3.14'",
+    "scikit-learn>=1.7.2; python_version >= '3.14'",
     "statsmodels>=0.14.0; python_version < '3.14'",
     "statsmodels>=0.14.6; python_version >= '3.14'",
 

--- a/src/ml4t/engineer/relationships/correlation.py
+++ b/src/ml4t/engineer/relationships/correlation.py
@@ -150,7 +150,7 @@ def compute_correlation_matrix(
         # Ensure features are numeric or all-null
         non_numeric = []
         for feat in features:
-            is_numeric = np.issubdtype(df[feat].dtype, np.number)
+            is_numeric = pd.api.types.is_numeric_dtype(df[feat].dtype)
             is_all_null = df[feat].dtype == object and df[feat].isna().all()
             if not (is_numeric or is_all_null):
                 non_numeric.append(feat)

--- a/uv.lock
+++ b/uv.lock
@@ -1453,7 +1453,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "scikit-learn", marker = "python_full_version < '3.14'", specifier = ">=1.3.0" },
-    { name = "scikit-learn", marker = "python_full_version >= '3.14'", specifier = ">=1.8.0" },
+    { name = "scikit-learn", marker = "python_full_version >= '3.14'", specifier = ">=1.7.2" },
     { name = "scipy", marker = "python_full_version < '3.14'", specifier = ">=1.10.0" },
     { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.17.0" },
     { name = "seaborn", marker = "extra == 'all'", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Summary
- lower the Python 3.14  floor from  to 
- keep the 3.14 compiled stack installable while avoiding unnecessary downstream conflicts
- fix pandas-3.0 dtype handling in 

## Verification
- uv run ruff check --no-fix src tests .github
- uv run ruff format --check src tests .github
- uv run ty check
- uv run --python 3.14 pytest tests/relationships/test_correlation.py::TestFeatureSelection::test_non_numeric_feature_error -q
- exact-minimum check clone with  on Python 3.14:  before the repo's known Numba teardown abort ()