### PR TITLE
fix: lower python 3.14 pandas floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ml4t-engineer are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b7] - 2026-05-05
+
+### Fixed
+- Lowered the Python 3.14 `pandas` floor from `>=3.0.0` to `>=2.3.3`, which
+  already publishes `cp314` wheels and avoids unnecessary dependency conflicts
+  downstream
+
 ## [0.1.0b6] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     # Data processing (Polars-first)
     "polars>=0.20.0",
     "pandas>=2.0.0; python_version < '3.14'",
-    "pandas>=3.0.0; python_version >= '3.14'",
+    "pandas>=2.3.3; python_version >= '3.14'",
     "numpy>=1.24.0,<2.5",
     "pyarrow>=14.0.0; python_version < '3.14'",
     "pyarrow>=23.0.0; python_version >= '3.14'",

--- a/uv.lock
+++ b/uv.lock
@@ -1426,7 +1426,7 @@ requires-dist = [
     { name = "numba", marker = "python_full_version >= '3.14'", specifier = ">=0.64.0" },
     { name = "numpy", specifier = ">=1.24.0,<2.5" },
     { name = "pandas", marker = "python_full_version < '3.14'", specifier = ">=2.0.0" },
-    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=3.0.0" },
+    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=2.3.3" },
     { name = "pandas-market-calendars", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "pandas-market-calendars", marker = "extra == 'calendars'", specifier = ">=4.0.0" },
     { name = "pandas-market-calendars", marker = "extra == 'dev'", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary
- lower the Python 3.14 pandas floor from >=3.0.0 to >=2.3.3
- keep the Python 3.14 scientific stack otherwise unchanged
- avoid unnecessary downstream conflicts with libraries that still cap below pandas 3

## Validation
- uv run ruff check src tests .github
- uv run ty check
- uv build
- exact-minimum Python 3.14 check with pandas==2.3.3: 2752 passed, 65 skipped, 24 deselected
- release-clone suite: 2752 passed, 65 skipped, 24 deselected