### PR TITLE
fix: relax python 3.14 dependency pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to ml4t-engineer are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b8] - 2026-05-05
+
+### Fixed
+- Dropped the Python 3.14-specific dependency split pins for `pandas`,
+  `pyarrow`, `scipy`, `scikit-learn`, `statsmodels`, and `numba`, keeping the
+  source-level minimums as unconditional requirements so resolvers can choose
+  the newest compatible builds for each platform
+
 ## [0.1.0b7] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,23 +75,17 @@ dependencies = [
 
     # Data processing (Polars-first)
     "polars>=0.20.0",
-    "pandas>=2.0.0; python_version < '3.14'",
-    "pandas>=2.3.3; python_version >= '3.14'",
+    "pandas>=2.0.0",
     "numpy>=1.24.0,<2.5",
-    "pyarrow>=14.0.0; python_version < '3.14'",
-    "pyarrow>=23.0.0; python_version >= '3.14'",
+    "pyarrow>=14.0.0",
 
     # Scientific computing
-    "scipy>=1.10.0; python_version < '3.14'",
-    "scipy>=1.17.0; python_version >= '3.14'",
-    "scikit-learn>=1.3.0; python_version < '3.14'",
-    "scikit-learn>=1.7.2; python_version >= '3.14'",
-    "statsmodels>=0.14.0; python_version < '3.14'",
-    "statsmodels>=0.14.6; python_version >= '3.14'",
+    "scipy>=1.10.0",
+    "scikit-learn>=1.3.0",
+    "statsmodels>=0.14.0",
 
     # Performance optimization
-    "numba>=0.57.0; python_version < '3.14'",
-    "numba>=0.64.0; python_version >= '3.14'",
+    "numba>=0.57.0",
 
     # Configuration
     "pydantic>=2.0.0",


### PR DESCRIPTION
Summary:
- drop Python 3.14-specific split pins for pandas, pyarrow, scipy, scikit-learn, statsmodels, and numba
- keep the package source-level minimums unconditional so downstream resolvers can choose newer compatible builds

Verification:
- constrained Python 3.14 resolution with pandas==2.3.3 and scikit-learn==1.6.1 succeeded
- full suite under that constrained environment: 2752 passed, 65 skipped, 24 deselected
- uv build passed