### PR TITLE
fix: a gap in the input never produces a silently wrong feature value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to ml4t-engineer are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`momentum.rsi` no longer saturates at 100 after a null in the input.** Wilder's
+  average is recursive and had no notion of a gap, and the kernel was compiled with
+  `fastmath=True`, which licenses the compiler to assume no NaN. One null returned
+  exactly `100.0` for the rest of the series. The input is now split on NaN and each
+  gap-free run is seeded on its own, so a gap costs the missing observation plus
+  `period` warmup rows and the oscillator then resumes.
+
+  Two published datasets carried this in their output. A crypto perpetual-funding
+  premium index with 537 nulls emitted `100.0` on 79.0% of 100,812 rows against a
+  hand-computed median of 49.68. A CME crude-oil series carried a **single** null,
+  on 2020-04-20, the day the contract settled negative and the caller's own
+  non-positive-price gate nulled it - 12.6% of that product's `rsi_14`, every one of
+  them after the null, running to the end of the series five years later.
+
+- **A missing observation no longer produces a silently wrong value anywhere in the
+  feature surface.** `fastmath=True` was the general mechanism, not an RSI detail.
+  Feeding one null into every momentum, volatility and volume feature, 20 of 91
+  feature-column pairs returned a finite number that differed from the correct one,
+  by up to 91.9 for `mfi` and 1.6e4 for the A/D line. `fastmath` is removed from the
+  feature kernels; `volume.obv` no longer freezes its level forever when both
+  comparisons against a NaN previous close are false; and `volume.ad`'s Polars path
+  no longer uses `cum_sum`, which skips nulls and carries the level on as if the bar
+  had been observed while the Numba path propagates. Every feature now either
+  recovers from a gap or returns NaN.
+
+  Measured cost over 5M rows: `rsi` 42.7 -> 53.8 ms, `atr` 51.4 -> 90.3 ms, `adx`
+  unchanged. No TA-Lib exactness result changed.
+
+- **`microstructure.amihud_illiquidity` averages over the periods that traded.**
+  Amihud (2002) divides by the number of days the asset traded; nulling untraded bars
+  and taking `rolling_mean(period)` propagates the null across the following window,
+  which instead required every bar in the window to have traded. On a NASDAQ-100
+  minute panel, 0.64% untraded bars produced a 9.08% null share.
+
+- **A rolling kernel is compiled before its window runs, not inside it.**
+  `polars.Expr.rolling_map` does not advance its window while the callback is being
+  compiled, so the first evaluation of a feature whose callback calls a lazily-jitted
+  kernel returned the first window's value for the entire series, near-constant, with
+  nothing raised. `regime.hurst_exponent`, `statistics.coefficient_of_variation`,
+  `statistics.rolling_cv_zscore`, `statistics.rolling_drift`, `ml.rolling_entropy_lz`
+  and `ml.rolling_entropy_plugin` each returned two distinct values on their first
+  evaluation in a process and the full set on every later one. Affects any fresh
+  environment - a new virtualenv, a CI job, a first run - and not a repeat run, which
+  loads the kernel already compiled.
+
 ## [0.1.0b9] - 2026-06-21
 
 ### Added

--- a/src/ml4t/engineer/_numba.py
+++ b/src/ml4t/engineer/_numba.py
@@ -30,3 +30,37 @@ def _load_numba_decorators() -> tuple[Any, Any, bool]:
 
 
 jit, njit, NUMBA_AVAILABLE = _load_numba_decorators()
+
+
+def warm_rolling_callback(callback: Callable[[Any], Any], window: int) -> None:
+    """Run ``callback`` once so its kernel compiles outside a rolling window.
+
+    ``polars.Expr.rolling_map`` does not advance its window while the callback is
+    being compiled. The first time a process evaluates a feature whose callback
+    calls a lazily-jitted kernel, every window therefore receives the first
+    window's value: the column comes out near-constant, and nothing raises.
+
+    Measured on a 600-row series, each feature returning two distinct values on its
+    first use in a process and the full set on every later one:
+    ``regime.hurst_exponent``, ``statistics.coefficient_of_variation``,
+    ``statistics.rolling_cv_zscore``, ``statistics.rolling_drift`` and
+    ``ml.rolling_entropy_lz``. It is what made ``etfs/03_financial_features`` fail
+    its withheld-rows check in CI and pass on a re-run, since the second run found
+    the kernel already compiled on disk.
+
+    Call this with the same ``window`` the ``rolling_map`` will use, so the probe
+    has the shape the kernel will be typed against.
+    """
+    if not NUMBA_AVAILABLE:
+        return
+
+    import numpy as np
+    import polars as pl
+
+    probe = pl.Series("warmup", np.linspace(1.0, 2.0, max(int(window), 2), dtype=np.float64))
+    try:
+        callback(probe)
+    except Exception:  # noqa: BLE001
+        # A probe the kernel rejects leaves the feature exactly as it was: the
+        # warm-up is an optimisation of when compilation happens, never a result.
+        return

--- a/src/ml4t/engineer/features/microstructure/amihud_illiquidity.py
+++ b/src/ml4t/engineer/features/microstructure/amihud_illiquidity.py
@@ -190,13 +190,18 @@ def amihud_illiquidity(
     # Amihud = |return| / dollar_volume
     # Use 1e-6 multiplier for readability (expressing as return per million dollars)
     # Protect against division by zero
-    amihud = (
-        pl.when(dollar_volume.abs() > 1e-10)
+    ratio = (
+        pl.when((dollar_volume.abs() > 1e-10) & returns.is_finite())
         .then(
             returns.abs() / dollar_volume * 1e6,
         )
         .otherwise(None)
-        .rolling_mean(period)
     )
 
-    return amihud
+    # Amihud (2002) averages over the D periods that traded, so a period with no
+    # trading leaves the window rather than emptying it. `rolling_mean` would
+    # propagate that null across the whole following window instead.
+    traded = ratio.is_not_null().cast(pl.UInt32).rolling_sum(period)
+    total = ratio.fill_null(0.0).rolling_sum(period)
+
+    return pl.when(traded > 0).then(total / traded).otherwise(None)

--- a/src/ml4t/engineer/features/ml/rolling_entropy.py
+++ b/src/ml4t/engineer/features/ml/rolling_entropy.py
@@ -35,7 +35,7 @@ import numpy as np
 import numpy.typing as npt
 import polars as pl
 
-from ml4t.engineer._numba import jit
+from ml4t.engineer._numba import jit, warm_rolling_callback
 from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.validation import validate_window
 from ml4t.engineer.logging import logged_feature
@@ -549,11 +549,13 @@ def rolling_entropy(
 
     feature_expr = pl.col(feature) if isinstance(feature, str) else feature
 
+    def compute_shannon_entropy(x: pl.Series) -> float:
+        arr = x.to_numpy().astype(np.float64) if hasattr(x, "to_numpy") else x
+        return _shannon_entropy_nb(arr, n_bins)
+
+    warm_rolling_callback(compute_shannon_entropy, window)
     return feature_expr.rolling_map(
-        lambda x: _shannon_entropy_nb(
-            x.to_numpy().astype(np.float64) if hasattr(x, "to_numpy") else x,
-            n_bins,
-        ),
+        compute_shannon_entropy,
         window_size=window,
         weights=None,
         min_samples=window // 2,
@@ -629,6 +631,7 @@ def rolling_entropy_lz(
 
         return _kontoyiannis_entropy_nb(encoded, window_size=len(arr) // 2)
 
+    warm_rolling_callback(compute_lz_entropy, window)
     return feature_expr.rolling_map(
         compute_lz_entropy,
         window_size=window,
@@ -704,6 +707,7 @@ def rolling_entropy_plugin(
 
         return _plugin_entropy_nb(encoded, word_length)
 
+    warm_rolling_callback(compute_plugin_entropy, window)
     return feature_expr.rolling_map(
         compute_plugin_entropy,
         window_size=window,

--- a/src/ml4t/engineer/features/momentum/adx.py
+++ b/src/ml4t/engineer/features/momentum/adx.py
@@ -18,7 +18,7 @@ from ml4t.engineer.logging import get_logger, logged_feature
 _logger = get_logger("ta.adx")
 
 
-@jit(nopython=True, cache=True, fastmath=True)
+@jit(nopython=True, cache=True)
 def _calculate_directional_movement(
     prev_high: float,
     current_high: float,
@@ -57,7 +57,7 @@ def _calculate_directional_movement(
     return 0.0, 0.0
 
 
-@jit(nopython=True, cache=True, fastmath=True)
+@jit(nopython=True, cache=True)
 def _calculate_true_range(high: float, low: float, prev_close: float) -> float:
     """Calculate True Range for a single period.
 
@@ -81,7 +81,7 @@ def _calculate_true_range(high: float, low: float, prev_close: float) -> float:
     return max(tr_hl, tr_hc, tr_lc)
 
 
-@jit(nopython=True, cache=True, fastmath=True)
+@jit(nopython=True, cache=True)
 def _apply_wilders_smoothing(
     prev_smoothed: float,
     new_value: float,
@@ -108,7 +108,7 @@ def _apply_wilders_smoothing(
     return prev_smoothed - (prev_smoothed / period) + new_value
 
 
-@jit(nopython=True, cache=True, fastmath=True)
+@jit(nopython=True, cache=True)
 def _calculate_dx(plus_di: float, minus_di: float) -> float:
     """Calculate Directional Index (DX) from Directional Indicators.
 
@@ -130,7 +130,7 @@ def _calculate_dx(plus_di: float, minus_di: float) -> float:
     return 100.0 * (abs(minus_di - plus_di) / sum_di)
 
 
-@jit(nopython=True, cache=True, fastmath=True)
+@jit(nopython=True, cache=True)
 def adx_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/apo.py
+++ b/src/ml4t/engineer/features/momentum/apo.py
@@ -16,7 +16,7 @@ from ml4t.engineer.features.trend.ema import ema_numba
 from ml4t.engineer.features.trend.sma import sma_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def apo_numba(
     close: npt.NDArray[np.float64],
     fast_period: int = 12,

--- a/src/ml4t/engineer/features/momentum/aroon.py
+++ b/src/ml4t/engineer/features/momentum/aroon.py
@@ -14,7 +14,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def aroon_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],
@@ -116,7 +116,7 @@ def aroon_numba(
     return aroon_down, aroon_up
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def aroonosc_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/cci.py
+++ b/src/ml4t/engineer/features/momentum/cci.py
@@ -9,7 +9,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def cci_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/cmo.py
+++ b/src/ml4t/engineer/features/momentum/cmo.py
@@ -15,7 +15,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def cmo_numba(close: npt.NDArray[np.float64], timeperiod: int = 14) -> npt.NDArray[np.float64]:
     """
     CMO calculation using Numba.

--- a/src/ml4t/engineer/features/momentum/directional.py
+++ b/src/ml4t/engineer/features/momentum/directional.py
@@ -15,7 +15,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def calculate_directional_movement_nb(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],
@@ -42,7 +42,7 @@ def calculate_directional_movement_nb(
     return plus_dm, minus_dm
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def wilders_smoothing_nb(close: npt.NDArray[np.float64], period: int) -> npt.NDArray[np.float64]:
     """
     Wilder's smoothing method matching TA-Lib implementation.
@@ -79,7 +79,7 @@ def wilders_smoothing_nb(close: npt.NDArray[np.float64], period: int) -> npt.NDA
     return result
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def plus_di_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],
@@ -142,7 +142,7 @@ def plus_di_numba(
     return result
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def minus_di_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],
@@ -205,7 +205,7 @@ def minus_di_numba(
     return result
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def dx_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/mfi.py
+++ b/src/ml4t/engineer/features/momentum/mfi.py
@@ -14,7 +14,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def mfi_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/ppo.py
+++ b/src/ml4t/engineer/features/momentum/ppo.py
@@ -16,7 +16,7 @@ from ml4t.engineer.features.trend.ema import ema_numba
 from ml4t.engineer.features.trend.sma import sma_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def ppo_numba(
     close: npt.NDArray[np.float64],
     fast_period: int = 12,

--- a/src/ml4t/engineer/features/momentum/roc.py
+++ b/src/ml4t/engineer/features/momentum/roc.py
@@ -9,7 +9,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def roc_numba(close: npt.NDArray[np.float64], period: int = 10) -> npt.NDArray[np.float64]:
     """ROC calculation using Numba for performance."""
     n = len(close)

--- a/src/ml4t/engineer/features/momentum/rsi.py
+++ b/src/ml4t/engineer/features/momentum/rsi.py
@@ -14,37 +14,25 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
-def rsi_numba(close: npt.NDArray[np.float64], period: int = 14) -> npt.NDArray[np.float64]:
-    """
-    RSI using Wilder's smoothing - exact TA-Lib algorithm.
-
-    Wilder's smoothing is different from EMA - it uses a different
-    averaging method that TA-Lib implements specifically for RSI.
-
-    Parameters
-    ----------
-    close : npt.NDArray
-        Price data
-    period : int, default 14
-        Number of periods for RSI calculation
-
-    Returns
-    -------
-    npt.NDArray
-        RSI close (0-100 scale) with NaN for insufficient data
-    """
-    n = len(close)
-    result = np.full(n, np.nan)
+@jit(nopython=True, cache=True)  # type: ignore[misc]
+def _rsi_run(
+    close: npt.NDArray[np.float64],
+    start: int,
+    stop: int,
+    period: int,
+    result: npt.NDArray[np.float64],
+) -> None:
+    """Write Wilder's RSI for the gap-free run ``close[start:stop]`` into ``result``."""
+    n = stop - start
 
     if period < 1 or period >= n:
-        return result
+        return
 
     # Calculate initial sums for the first period
     sum_gain = 0.0
     sum_loss = 0.0
 
-    for i in range(1, period + 1):
+    for i in range(start + 1, start + period + 1):
         change = close[i] - close[i - 1]
         if change > 0:
             sum_gain += change
@@ -57,19 +45,19 @@ def rsi_numba(close: npt.NDArray[np.float64], period: int = 14) -> npt.NDArray[n
 
     if avg_loss != 0:
         rs = avg_gain / avg_loss
-        result[period] = 100.0 - (100.0 / (1.0 + rs))
+        result[start + period] = 100.0 - (100.0 / (1.0 + rs))
     # When avg_loss is 0, TA-Lib returns 0 if avg_gain is also 0
     elif avg_gain == 0:
-        result[period] = 0.0
+        result[start + period] = 0.0
     else:
-        result[period] = 100.0
+        result[start + period] = 100.0
 
     # Calculate subsequent RSI close using Wilder's smoothing
     # Pre-compute constant
     factor = (period - 1.0) / period
     inv_period = 1.0 / period
 
-    for i in range(period + 1, n):
+    for i in range(start + period + 1, stop):
         change = close[i] - close[i - 1]
 
         if change > 0:
@@ -87,6 +75,47 @@ def rsi_numba(close: npt.NDArray[np.float64], period: int = 14) -> npt.NDArray[n
             result[i] = 0.0
         else:
             result[i] = 100.0
+
+
+@jit(nopython=True, cache=True)  # type: ignore[misc]
+def rsi_numba(close: npt.NDArray[np.float64], period: int = 14) -> npt.NDArray[np.float64]:
+    """
+    RSI using Wilder's smoothing - exact TA-Lib algorithm.
+
+    Wilder's smoothing is different from EMA - it uses a different
+    averaging method that TA-Lib implements specifically for RSI.
+
+    Wilder's average is recursive, so a missing observation has no defined
+    successor: the input is split on NaN and each gap-free run is seeded and
+    smoothed on its own, exactly as the start of the series is. A run shorter
+    than ``period + 1`` yields NaN, and the ``period`` observations that follow
+    a gap are NaN while the new run warms up.
+
+    Parameters
+    ----------
+    close : npt.NDArray
+        Price data
+    period : int, default 14
+        Number of periods for RSI calculation
+
+    Returns
+    -------
+    npt.NDArray
+        RSI close (0-100 scale) with NaN for insufficient data
+    """
+    n = len(close)
+    result = np.full(n, np.nan)
+
+    start = 0
+    while start < n:
+        if np.isnan(close[start]):
+            start += 1
+            continue
+        stop = start + 1
+        while stop < n and not np.isnan(close[stop]):
+            stop += 1
+        _rsi_run(close, start, stop, period, result)
+        start = stop
 
     return result
 
@@ -108,7 +137,7 @@ def rsi_polars(column: str, period: int = 14) -> pl.Expr:
         Polars expression for RSI calculation
     """
     return pl.col(column).map_batches(
-        lambda s: pl.Series(rsi_numba(s.to_numpy(), period)),
+        lambda s: pl.Series(rsi_numba(s.cast(pl.Float64).to_numpy(), period)),
         return_dtype=pl.Float64,
     )
 
@@ -164,6 +193,9 @@ def rsi(
     - RSI = 100 - (100 / (1 + RS)) where RS = Average Gain / Average Loss
     - First average uses simple mean, subsequent close use Wilder's smoothing
     - Standard period is 14, commonly used close are 7, 14, 21
+    - A missing observation ends the recursion: the series is split on NaN and
+      each gap-free run is seeded separately, so the ``period`` observations
+      after a gap are NaN and the oscillator then resumes
     """
     # Validate parameters
     if period < 1:
@@ -173,8 +205,8 @@ def rsi(
         return rsi_polars(close, period)
 
     if isinstance(close, pl.Series):
-        close = close.to_numpy()
-    return rsi_numba(close, period)
+        close = close.cast(pl.Float64).to_numpy()
+    return rsi_numba(np.asarray(close, dtype=np.float64), period)
 
 
 # Export the main function

--- a/src/ml4t/engineer/features/momentum/sar.py
+++ b/src/ml4t/engineer/features/momentum/sar.py
@@ -14,7 +14,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def sar_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/trix.py
+++ b/src/ml4t/engineer/features/momentum/trix.py
@@ -20,7 +20,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.features.trend.ema import ema_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def trix_numba(close: npt.NDArray[np.float64], timeperiod: int = 30) -> npt.NDArray[np.float64]:
     """
     TRIX calculation using Numba.

--- a/src/ml4t/engineer/features/momentum/ultosc.py
+++ b/src/ml4t/engineer/features/momentum/ultosc.py
@@ -21,7 +21,7 @@ from ml4t.engineer._numba import njit
 from ml4t.engineer.core.decorators import feature
 
 
-@njit(cache=True, fastmath=True)  # type: ignore[misc]
+@njit(cache=True)  # type: ignore[misc]
 def ultosc_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/momentum/willr.py
+++ b/src/ml4t/engineer/features/momentum/willr.py
@@ -9,7 +9,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def willr_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/price_transform/avgprice.py
+++ b/src/ml4t/engineer/features/price_transform/avgprice.py
@@ -14,7 +14,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def avgprice_numba(
     open: npt.NDArray[np.float64],
     high: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/price_transform/medprice.py
+++ b/src/ml4t/engineer/features/price_transform/medprice.py
@@ -17,7 +17,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def medprice_numba(
     high: npt.NDArray[np.float64], low: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:

--- a/src/ml4t/engineer/features/price_transform/typprice.py
+++ b/src/ml4t/engineer/features/price_transform/typprice.py
@@ -17,7 +17,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def typprice_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/price_transform/wclprice.py
+++ b/src/ml4t/engineer/features/price_transform/wclprice.py
@@ -17,7 +17,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def wclprice_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/regime.py
+++ b/src/ml4t/engineer/features/regime.py
@@ -27,7 +27,7 @@ import numpy as np
 import numpy.typing as npt
 import polars as pl
 
-from ml4t.engineer._numba import jit
+from ml4t.engineer._numba import jit, warm_rolling_callback
 from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.validation import (
     validate_list_length,
@@ -405,6 +405,7 @@ def hurst_exponent(
         except (ZeroDivisionError, ValueError, RuntimeError):
             return float(np.nan)
 
+    warm_rolling_callback(safe_hurst, period)
     return close.rolling_map(
         safe_hurst,
         window_size=period,

--- a/src/ml4t/engineer/features/statistics/avgdev.py
+++ b/src/ml4t/engineer/features/statistics/avgdev.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def avgdev_numba(close: npt.NDArray[np.float64], timeperiod: int = 14) -> npt.NDArray[np.float64]:
     """
     AVGDEV calculation using Numba.

--- a/src/ml4t/engineer/features/statistics/linearreg.py
+++ b/src/ml4t/engineer/features/statistics/linearreg.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def linearreg_numba(
     close: npt.NDArray[np.float64], timeperiod: int = 14
 ) -> npt.NDArray[np.float64]:

--- a/src/ml4t/engineer/features/statistics/linearreg_angle.py
+++ b/src/ml4t/engineer/features/statistics/linearreg_angle.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def linearreg_angle_numba(
     close: npt.NDArray[np.float64], timeperiod: int = 14
 ) -> npt.NDArray[np.float64]:

--- a/src/ml4t/engineer/features/statistics/linearreg_intercept.py
+++ b/src/ml4t/engineer/features/statistics/linearreg_intercept.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def linearreg_intercept_numba(
     close: npt.NDArray[np.float64], timeperiod: int = 14
 ) -> npt.NDArray[np.float64]:

--- a/src/ml4t/engineer/features/statistics/linearreg_slope.py
+++ b/src/ml4t/engineer/features/statistics/linearreg_slope.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def linearreg_slope_numba(
     close: npt.NDArray[np.float64], timeperiod: int = 14
 ) -> npt.NDArray[np.float64]:

--- a/src/ml4t/engineer/features/statistics/stddev.py
+++ b/src/ml4t/engineer/features/statistics/stddev.py
@@ -12,7 +12,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def stddev_numba(
     close: npt.NDArray[np.float64],
     period: int = 5,

--- a/src/ml4t/engineer/features/statistics/structural_break.py
+++ b/src/ml4t/engineer/features/statistics/structural_break.py
@@ -43,7 +43,7 @@ import numpy as np
 import numpy.typing as npt
 import polars as pl
 
-from ml4t.engineer._numba import jit
+from ml4t.engineer._numba import jit, warm_rolling_callback
 from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.validation import validate_window
 from ml4t.engineer.logging import logged_feature
@@ -127,8 +127,12 @@ def coefficient_of_variation(
     validate_window(window, min_window=2, name="window")
     feature_expr = pl.col(feature) if isinstance(feature, str) else feature
 
+    def compute(x: pl.Series) -> float:
+        return _cv_nb(x.to_numpy().astype(np.float64))
+
+    warm_rolling_callback(compute, window)
     return feature_expr.rolling_map(
-        lambda x: _cv_nb(x.to_numpy().astype(np.float64)),
+        compute,
         window_size=window,
         weights=None,
         min_samples=window // 2,
@@ -219,8 +223,12 @@ def rolling_cv_zscore(
     feature_expr = pl.col(feature) if isinstance(feature, str) else feature
     total_lookback = window * lookback_multiplier
 
+    def compute(x: pl.Series) -> float:
+        return _cv_zscore_nb(x.to_numpy().astype(np.float64), window)
+
+    warm_rolling_callback(compute, total_lookback)
     return feature_expr.rolling_map(
-        lambda x: _cv_zscore_nb(x.to_numpy().astype(np.float64), window),
+        compute,
         window_size=total_lookback,
         weights=None,
         min_samples=total_lookback // 2,
@@ -315,8 +323,12 @@ def variance_ratio(
     feature_expr = pl.col(feature) if isinstance(feature, str) else feature
 
     # Cast to Float64 to ensure consistent return type from rolling_map
+    def compute(x: pl.Series) -> float:
+        return _variance_ratio_nb(x.to_numpy().astype(np.float64), q)
+
+    warm_rolling_callback(compute, window)
     return feature_expr.cast(pl.Float64).rolling_map(
-        lambda x: _variance_ratio_nb(x.to_numpy().astype(np.float64), q),
+        compute,
         window_size=window,
         weights=None,
         min_samples=window // 2,
@@ -432,8 +444,12 @@ def rolling_kl_divergence(
     validate_window(n_bins, min_window=5, name="n_bins")
     feature_expr = pl.col(feature) if isinstance(feature, str) else feature
 
+    def compute(x: pl.Series) -> float:
+        return _kl_divergence_nb(x.to_numpy().astype(np.float64), len(x) // 2, n_bins)
+
+    warm_rolling_callback(compute, window)
     return feature_expr.rolling_map(
-        lambda x: _kl_divergence_nb(x.to_numpy().astype(np.float64), len(x) // 2, n_bins),
+        compute,
         window_size=window,
         weights=None,
         min_samples=window // 2,
@@ -538,8 +554,12 @@ def rolling_wasserstein(
     validate_window(window, min_window=10, name="window")
     feature_expr = pl.col(feature) if isinstance(feature, str) else feature
 
+    def compute(x: pl.Series) -> float:
+        return _wasserstein_1d_nb(x.to_numpy().astype(np.float64))
+
+    warm_rolling_callback(compute, window)
     return feature_expr.rolling_map(
-        lambda x: _wasserstein_1d_nb(x.to_numpy().astype(np.float64)),
+        compute,
         window_size=window,
         weights=None,
         min_samples=window // 2,
@@ -650,8 +670,12 @@ def rolling_drift(
 
     fn = _drift_zscore_nb if normalize else _drift_nb
 
+    def compute(x: pl.Series) -> float:
+        return fn(x.to_numpy().astype(np.float64))
+
+    warm_rolling_callback(compute, window)
     return feature_expr.rolling_map(
-        lambda x: fn(x.to_numpy().astype(np.float64)),
+        compute,
         window_size=window,
         weights=None,
         min_samples=window // 2,

--- a/src/ml4t/engineer/features/statistics/var.py
+++ b/src/ml4t/engineer/features/statistics/var.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def var_numba(
     close: npt.NDArray[np.float64],
     timeperiod: int = 5,

--- a/src/ml4t/engineer/features/trend/dema.py
+++ b/src/ml4t/engineer/features/trend/dema.py
@@ -15,7 +15,7 @@ from ml4t.engineer.core.decorators import feature
 from .ema import ema_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def dema_numba(close: npt.NDArray[np.float64], period: int = 30) -> npt.NDArray[np.float64]:
     """
     DEMA calculation exactly replicating TA-Lib algorithm.

--- a/src/ml4t/engineer/features/trend/midpoint.py
+++ b/src/ml4t/engineer/features/trend/midpoint.py
@@ -12,7 +12,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def midpoint_numba(close: npt.NDArray[np.float64], timeperiod: int = 14) -> npt.NDArray[np.float64]:
     """
     MIDPOINT calculation using optimized sliding window.

--- a/src/ml4t/engineer/features/trend/t3.py
+++ b/src/ml4t/engineer/features/trend/t3.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def t3_numba(
     close: npt.NDArray[np.float64],
     timeperiod: int = 5,

--- a/src/ml4t/engineer/features/trend/trima.py
+++ b/src/ml4t/engineer/features/trend/trima.py
@@ -15,7 +15,7 @@ from ml4t.engineer.core.decorators import feature
 from .sma import sma_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def trima_numba(close: npt.NDArray[np.float64], period: int = 30) -> npt.NDArray[np.float64]:
     """
     Triangular Moving Average calculation exactly matching TA-Lib.

--- a/src/ml4t/engineer/features/trend/wma.py
+++ b/src/ml4t/engineer/features/trend/wma.py
@@ -15,7 +15,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def wma_numba(close: npt.NDArray[np.float64], period: int) -> npt.NDArray[np.float64]:
     """
     Weighted Moving Average using Numba JIT compilation.

--- a/src/ml4t/engineer/features/volatility/atr.py
+++ b/src/ml4t/engineer/features/volatility/atr.py
@@ -14,7 +14,7 @@ from ml4t.engineer.core.decorators import feature
 from ml4t.engineer.core.exceptions import InvalidParameterError
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def true_range_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],
@@ -58,7 +58,7 @@ def true_range_numba(
     return result
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def atr_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/volatility/bollinger_bands.py
+++ b/src/ml4t/engineer/features/volatility/bollinger_bands.py
@@ -16,7 +16,7 @@ from ml4t.engineer.features.statistics.stddev import stddev_numba
 from ml4t.engineer.features.trend.sma import sma_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def bollinger_bands_numba(
     close: npt.NDArray[np.float64],
     period: int = 20,

--- a/src/ml4t/engineer/features/volatility/natr.py
+++ b/src/ml4t/engineer/features/volatility/natr.py
@@ -17,7 +17,7 @@ from ml4t.engineer.core.decorators import feature
 from .atr import atr_numba
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def natr_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/volatility/trange.py
+++ b/src/ml4t/engineer/features/volatility/trange.py
@@ -19,7 +19,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def trange_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/volume/ad.py
+++ b/src/ml4t/engineer/features/volume/ad.py
@@ -115,8 +115,18 @@ def ad_polars(high: str, low_col: str, close_col: str, volume_col: str) -> pl.Ex
     # Money Flow Volume
     mfv = mfm * pl.col(volume_col)
 
+    # `cum_sum` skips nulls, which would silently drop a missing bar's flow and
+    # carry the level on as if it had been observed. The Numba path propagates
+    # instead, so a missing bar has to end this series the same way.
+    observed = (
+        pl.col(high).is_not_null()
+        & pl.col(low_col).is_not_null()
+        & pl.col(close_col).is_not_null()
+        & pl.col(volume_col).is_not_null()
+    )
+
     # Cumulative sum for A/D Line
-    return mfv.cum_sum()
+    return pl.when(observed.cast(pl.UInt32).cum_min() == 1).then(mfv.cum_sum()).otherwise(None)
 
 
 @feature(

--- a/src/ml4t/engineer/features/volume/adosc.py
+++ b/src/ml4t/engineer/features/volume/adosc.py
@@ -10,7 +10,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def adosc_numba(
     high: npt.NDArray[np.float64],
     low: npt.NDArray[np.float64],

--- a/src/ml4t/engineer/features/volume/obv.py
+++ b/src/ml4t/engineer/features/volume/obv.py
@@ -13,7 +13,7 @@ from ml4t.engineer._numba import jit
 from ml4t.engineer.core.decorators import feature
 
 
-@jit(nopython=True, cache=True, fastmath=True)  # type: ignore[misc]
+@jit(nopython=True, cache=True)  # type: ignore[misc]
 def obv_numba(
     close: npt.NDArray[np.float64], volume: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
@@ -46,6 +46,12 @@ def obv_numba(
 
     result = np.zeros(n)
 
+    # A missing bar leaves the running total undefined, and comparing against a
+    # NaN previous close is false in both directions, which would freeze the
+    # level at its last value instead. Propagate, as the A/D line does.
+    if np.isnan(close[0]) or np.isnan(volume[0]):
+        return np.full(n, np.nan)
+
     # Initialize with first volume
     prev_obv = volume[0]
     prev_close = close[0]
@@ -53,6 +59,11 @@ def obv_numba(
 
     # Calculate OBV
     for i in range(1, n):
+        if np.isnan(close[i]) or np.isnan(volume[i]):
+            for j in range(i, n):
+                result[j] = np.nan
+            break
+
         if close[i] > prev_close:
             prev_obv += volume[i]
         elif close[i] < prev_close:

--- a/tests/features/test_microstructure.py
+++ b/tests/features/test_microstructure.py
@@ -306,6 +306,58 @@ def test_amihud_positive_values(sample_microstructure_data):
     assert np.all(amihud_values >= 0)
 
 
+def test_amihud_averages_over_the_bars_that_traded():
+    """An untraded bar leaves the window; it does not empty it.
+
+    Amihud (2002) sums over the D periods the asset traded and divides by D. A
+    `rolling_mean` over a series nulled on untraded bars instead requires every bar
+    in the window to have traded, which nulled 9.08% of the NASDAQ-100 minute panel
+    at period=30 from 0.64% untraded bars.
+    """
+    n = 100
+    period = 10
+    rng = np.random.default_rng(1)
+    returns = rng.normal(0, 0.01, n)
+    volume = np.full(n, 1e5)
+    volume[50] = 0.0  # one bar with no trading
+    close = np.full(n, 100.0)
+
+    frame = pl.DataFrame({"returns": returns, "volume": volume, "close": close})
+    result = frame.select(
+        amihud_illiquidity("returns", "volume", "close", period=period).alias("illiq")
+    )["illiq"]
+
+    # Only the warmup is null: the untraded bar costs its own contribution, not
+    # the following `period` rows.
+    assert result.is_null().arg_true().to_list() == list(range(period - 1))
+
+    # The reported value is the mean over the bars in the window that traded.
+    window = slice(46, 56)
+    dollar_volume = close[window] * volume[window]
+    traded = dollar_volume > 1e-10
+    expected = np.mean(np.abs(returns[window][traded]) / dollar_volume[traded] * 1e6)
+    assert result[55] == pytest.approx(expected)
+
+
+def test_amihud_is_null_only_where_nothing_traded():
+    """A window in which no bar traded has no Amihud value to report."""
+    n = 40
+    frame = pl.DataFrame(
+        {
+            "returns": np.full(n, 0.01),
+            "volume": np.concatenate([np.full(20, 1e5), np.zeros(20)]),
+            "close": np.full(n, 100.0),
+        }
+    )
+    result = frame.select(amihud_illiquidity("returns", "volume", "close", period=5).alias("i"))[
+        "i"
+    ]
+
+    assert result[19] is not None  # last fully traded window
+    assert result[23] is not None  # window still holds one traded bar
+    assert result[25] is None  # nothing in the window traded
+
+
 # =============================================================================
 # Roll Spread Tests
 # =============================================================================

--- a/tests/features/test_missing_observation_handling.py
+++ b/tests/features/test_missing_observation_handling.py
@@ -1,0 +1,141 @@
+"""A missing observation must never produce a silently wrong indicator value.
+
+Every feature here is computed twice on the same series, once clean and once with a
+single observation removed, and the two are compared. A gap may cost the indicator a
+warmup, and it may make the rest of the series NaN, but it may not return a finite
+number that differs from the number the clean series produced. Before this was
+enforced, one null in the input of ``momentum.rsi`` returned exactly ``100.0`` for
+87.5% of the remaining series, and nineteen other feature-column pairs returned a
+finite number that was simply wrong.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import polars as pl
+import pytest
+
+from ml4t.engineer.features import momentum, volatility, volume
+
+N = 2000
+HOLE = 500
+TAIL = slice(-200, None)
+
+# Wilder's average has infinite memory with geometric decay, so a re-seeded
+# recursion converges towards the clean series rather than reaching it exactly.
+# A silently wrong value differs by order 1 to 1e4, so this separates the two.
+RTOL = 1e-6
+
+# feature name -> (expression builder, the columns it is driven by)
+FEATURES: dict[str, tuple[Callable[[], pl.Expr], list[str]]] = {
+    "rsi": (lambda: momentum.rsi("close", period=14), ["close"]),
+    "cmo": (lambda: momentum.cmo("close", timeperiod=14), ["close"]),
+    "adx": (lambda: momentum.adx("high", "low", "close", period=14), ["high", "low", "close"]),
+    "dx": (lambda: momentum.dx("high", "low", "close", timeperiod=14), ["high", "low", "close"]),
+    "plus_di": (
+        lambda: momentum.plus_di("high", "low", "close", timeperiod=14),
+        ["high", "low", "close"],
+    ),
+    "minus_di": (
+        lambda: momentum.minus_di("high", "low", "close", timeperiod=14),
+        ["high", "low", "close"],
+    ),
+    "mfi": (
+        lambda: momentum.mfi("high", "low", "close", "volume", period=14),
+        ["high", "low", "close", "volume"],
+    ),
+    "cci": (lambda: momentum.cci("high", "low", "close", period=20), ["high", "low", "close"]),
+    "ultosc": (lambda: momentum.ultosc("high", "low", "close"), ["high", "low", "close"]),
+    "macd": (lambda: momentum.macd("close"), ["close"]),
+    "stochrsi": (lambda: momentum.stochrsi("close"), ["close"]),
+    "stochastic": (lambda: momentum.stochastic("high", "low", "close"), ["high", "low", "close"]),
+    "willr": (lambda: momentum.willr("high", "low", "close", period=14), ["high", "low", "close"]),
+    "atr": (lambda: volatility.atr("high", "low", "close", period=14), ["high", "low", "close"]),
+    "natr": (lambda: volatility.natr("high", "low", "close", period=14), ["high", "low", "close"]),
+    "obv": (lambda: volume.obv("close", "volume"), ["close", "volume"]),
+    "ad": (
+        lambda: volume.ad("high", "low", "close", "volume"),
+        ["high", "low", "close", "volume"],
+    ),
+    "adosc": (
+        lambda: volume.adosc("high", "low", "close", "volume"),
+        ["high", "low", "close", "volume"],
+    ),
+}
+
+CASES = [(name, driver) for name, (_, drivers) in FEATURES.items() for driver in drivers]
+
+
+def _panel() -> pl.DataFrame:
+    rng = np.random.default_rng(7)
+    close = 100 + np.cumsum(rng.normal(0.01, 1.0, N))
+    return pl.DataFrame(
+        {
+            "close": close,
+            "high": close + np.abs(rng.normal(0.5, 0.2, N)),
+            "low": close - np.abs(rng.normal(0.5, 0.2, N)),
+            "open": close + rng.normal(0.0, 0.3, N),
+            "volume": rng.integers(1_000, 100_000, N).astype(float),
+        }
+    )
+
+
+def _with_hole(frame: pl.DataFrame, column: str) -> pl.DataFrame:
+    return frame.with_columns(
+        pl.when(pl.int_range(pl.len()) == HOLE).then(None).otherwise(pl.col(column)).alias(column)
+    )
+
+
+def _values(frame: pl.DataFrame, expr: pl.Expr) -> np.ndarray:
+    out = frame.select(expr)
+    series = out.to_series(0)
+    if series.dtype == pl.Struct:
+        series = out.unnest(out.columns[0]).to_series(0)
+    return series.to_numpy().astype(float)
+
+
+@pytest.mark.parametrize(("feature", "driver"), CASES, ids=[f"{f}-{d}" for f, d in CASES])
+def test_one_missing_bar_is_never_silently_absorbed(feature: str, driver: str) -> None:
+    frame = _panel()
+    build, _ = FEATURES[feature]
+
+    clean = _values(frame, build())
+    holed = _values(_with_hole(frame, driver), build())
+
+    finite_in_both = np.isfinite(clean) & np.isfinite(holed)
+    disagree = finite_in_both & ~np.isclose(clean, holed, rtol=RTOL, atol=1e-9)
+
+    # A gap may cost the indicator a warmup, so allow disagreement while it
+    # re-seeds, but never at the end of the series.
+    tail_disagree = np.flatnonzero(disagree[TAIL])
+    assert tail_disagree.size == 0, (
+        f"{feature} returns a finite but different value at the end of the series when "
+        f"one {driver} bar is missing: "
+        f"clean {clean[TAIL][tail_disagree][:3]} vs holed {holed[TAIL][tail_disagree][:3]}"
+    )
+
+
+def test_rsi_does_not_saturate_after_a_gap() -> None:
+    """The exact failure this suite exists for: one null, then 100.0 forever."""
+    rng = np.random.default_rng(0)
+    close = 100 + np.cumsum(rng.normal(0.01, 1.0, 4000))
+    holed = close.copy()
+    holed[500] = np.nan
+
+    clean_out = momentum.rsi(close, period=9)
+    holed_out = momentum.rsi(holed, period=9)
+
+    after_gap = holed_out[501:]
+    finite = after_gap[np.isfinite(after_gap)]
+    assert finite.size > 3000
+    assert np.mean(finite == 100.0) == 0.0, "RSI saturated at 100 after a gap"
+
+    # The gap costs exactly `period` observations: the missing bar and its warmup.
+    assert np.all(np.isnan(holed_out[500:510]))
+    assert np.isfinite(holed_out[510])
+
+    # Everything before the gap is untouched, and the recursion re-converges after it.
+    np.testing.assert_allclose(clean_out[:500], holed_out[:500])
+    np.testing.assert_allclose(clean_out[-500:], holed_out[-500:], rtol=1e-9, atol=1e-9)

--- a/tests/features/test_rolling_map_first_call.py
+++ b/tests/features/test_rolling_map_first_call.py
@@ -1,0 +1,96 @@
+"""A feature's first evaluation in a process must equal its second.
+
+``polars.Expr.rolling_map`` does not advance its window while the callback is being
+compiled, so a feature whose callback calls a lazily-jitted kernel used to return the
+first window's value for the entire series the first time a process evaluated it.
+Nothing raised: the column came out near-constant. On a 600-row series, five features
+returned two distinct values on their first use and the full set on every later one.
+
+That is what made ``etfs/03_financial_features`` fail its withheld-rows check in CI
+and pass when re-run by hand: CI compiles, a re-run loads the compiled kernel from
+disk. It was read as a point-in-time leak and as CPU contention; it was neither.
+
+Each case runs in its own interpreter with its own empty Numba cache directory,
+because "the first call in a process, with nothing compiled" is the condition.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# feature -> the expression to build, as source, against columns `close` and `returns`
+FEATURES = {
+    "hurst_exponent": 'regime.hurst_exponent("close", period=100)',
+    "coefficient_of_variation": 'statistics.coefficient_of_variation("close", window=50)',
+    "rolling_cv_zscore": 'statistics.rolling_cv_zscore("close", window=20)',
+    "variance_ratio": 'statistics.variance_ratio("returns", window=50)',
+    "rolling_kl_divergence": 'statistics.rolling_kl_divergence("returns", window=50)',
+    "rolling_wasserstein": 'statistics.rolling_wasserstein("returns", window=50)',
+    "rolling_drift": 'statistics.rolling_drift("returns", window=50)',
+    "rolling_entropy": 'ml.rolling_entropy("returns", window=100)',
+    "rolling_entropy_lz": 'ml.rolling_entropy_lz("returns", window=100)',
+    "rolling_entropy_plugin": 'ml.rolling_entropy_plugin("returns", window=100)',
+    "wma": 'trend.wma("close", period=30)',
+    "volatility_percentile_rank": 'volatility.volatility_percentile_rank("returns", lookback=100)',
+}
+
+PROBE = textwrap.dedent(
+    """
+    import logging, warnings
+    warnings.filterwarnings("ignore")
+    logging.disable(logging.WARNING)
+
+    import numpy as np
+    import polars as pl
+    from ml4t.engineer.features import ml, regime, statistics, trend, volatility
+
+    rng = np.random.default_rng(11)
+    close = 100 * np.exp(np.cumsum(rng.normal(0, 0.01, 600)))
+    returns = np.diff(close, prepend=close[0]) / close
+    frame = pl.DataFrame({{"close": close, "returns": returns}})
+
+    def evaluate():
+        values = frame.select(({expr}).alias("v")).to_series().to_numpy().astype(float)
+        finite = values[np.isfinite(values)]
+        return len(np.unique(finite)), finite.size
+
+    first, n = evaluate()
+    second, _ = evaluate()
+    print(f"{{first}} {{second}} {{n}}")
+    """
+)
+
+
+def _run(expr: str, tmp_path) -> tuple[int, int, int]:
+    """Evaluate the feature twice in a fresh interpreter with an empty Numba cache."""
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(tmp_path), PYTHONWARNINGS="ignore")
+    completed = subprocess.run(
+        [sys.executable, "-c", PROBE.format(expr=expr)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=600,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"probe failed:\n{completed.stderr[-2000:]}")
+    first, second, n = (int(part) for part in completed.stdout.strip().split()[-3:])
+    return first, second, n
+
+
+@pytest.mark.parametrize("name", sorted(FEATURES))
+def test_first_evaluation_matches_the_second(name: str, tmp_path) -> None:
+    first, second, n = _run(FEATURES[name], tmp_path)
+
+    assert n > 100, f"{name} produced almost nothing to compare"
+    assert first == second, (
+        f"{name} returns {first} distinct values on its first evaluation in a process "
+        f"and {second} on its second, over {n} rows: the rolling window did not advance "
+        f"while the kernel compiled"
+    )
+    assert first > 2, f"{name} came out near-constant ({first} distinct values over {n} rows)"


### PR DESCRIPTION
Three defects with one shape: an indicator handed a series with a gap, or evaluated
for the first time in a process, returned a finite number that was simply wrong,
with nothing raised and nothing null.

Closes #30. Closes #31.

## `amihud_illiquidity` averaged over the whole window, not the traded bars (#31)

Amihud (2002) averages `|R| / DVOL` over the D periods the asset traded and divides
by D. Nulling untraded bars and taking `rolling_mean(period)` propagates the null
across the following window instead, so the implementation required *every* bar in
the window to have traded. On the NASDAQ-100 minute panel at `period=30`, 0.64%
untraded bars produced a 9.08% null share. The denominator now counts the bars in
the window that traded.

## `momentum.rsi` saturated at 100 after one null (#30)

Wilder's average is recursive and had no notion of a gap. Compiled with
`fastmath=True`, which licenses LLVM to assume no NaN, one null returned exactly
`100.0` for 87.5% of the remaining series: median 49.55 -> 100.0 on a 4,000-point
random walk. The series is now split on NaN and each gap-free run is seeded on its
own, so a gap costs the missing bar plus `period` warmup observations and the
oscillator resumes. On that series the gap nulls indices 500-509 and the tail
matches the clean series exactly.

## `fastmath` was doing this across the feature surface

`fastmath=True` is what turned NaN propagation into silent garbage generally.
Feeding one null into every momentum, volatility and volume feature and comparing
against the clean series, **20 of 91 feature-column pairs returned a finite value
that differed from the correct one**, up to 91.9 for `mfi` and 1.6e4 for the A/D
line. Removing `fastmath` leaves 6; fixing `obv`, `ad` and the polars A/D path
leaves **0**. Every feature now either recovers from a gap or returns NaN.

`obv` froze its level forever, because both comparisons against a NaN previous
close are false. `ad_polars` used `cum_sum`, which skips nulls and carries the level
on as if the bar had been observed, while `ad_numba` propagates and the docstring
says it propagates. Both now propagate.

Cost, 5M rows: `rsi` 42.7 -> 53.8 ms, `atr` 51.4 -> 90.3 ms, `adx` unchanged. No
TA-Lib exactness test moved.

## A rolling kernel compiled inside its own window

Found while investigating a downstream seal-check failure. `polars.Expr.rolling_map`
does not advance its window while the callback is being compiled, so a feature whose
callback calls a lazily-jitted kernel returned the first window's value for the whole
series the first time a process evaluated it. Distinct values on the first evaluation
against the second, each in a fresh interpreter with an empty Numba cache, over a
600-row series:

| feature | first | second |
|---|---|---|
| `regime.hurst_exponent` | 2 | 501 |
| `statistics.coefficient_of_variation` | 2 | 576 |
| `statistics.rolling_cv_zscore` | 2 | 551 |
| `statistics.rolling_drift` | 2 | 576 |
| `ml.rolling_entropy_lz` | 2 | 94 |
| `ml.rolling_entropy_plugin` | 2 | 46 |

`warm_rolling_callback` runs the callback once on a probe window of the right length
so compilation happens first. Applied at all ten sites with a jitted callback,
including the four that measured clean, so no site depends on which kernels another
feature happened to compile.

## Tests

- `tests/features/test_missing_observation_handling.py` - one missing bar against 18
  recursive and cumulative features. 23 cases fail without the fixes.
- `tests/features/test_rolling_map_first_call.py` - each of the twelve
  rolling_map-backed features in its own interpreter with its own `NUMBA_CACHE_DIR`,
  first evaluation against second. 6 fail without the warm-up.
- `tests/features/test_microstructure.py` - two Amihud tests, one hand-computing the
  average over the traded bars.

Full suite: 3913 passed, 1 skipped. `ruff check`, `ruff format`, `ty check` clean.

Note for anyone bisecting: Numba's `cache=True` does not invalidate when a jitted
*callee* changes, so delete `src/**/__pycache__/*.nb[ic]` after editing a kernel or
the old machine code is silently reused.